### PR TITLE
change int cast on combo elements

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -222,7 +222,7 @@ class TextEncodeQwenImageEditPlusAdvance_lrzjason:
                 if image is not None:
                     samples = image.movedim(-1, 1)
                     current_total = (samples.shape[3] * samples.shape[2])
-                    total = int(target_size * target_size)
+                    total = int(target_size) * int(target_size)
                     scale_by = math.sqrt(total / current_total)
                     width = round(samples.shape[3] * scale_by / 64.0) * 64
                     height = round(samples.shape[2] * scale_by / 64.0) * 64


### PR DESCRIPTION
Technically this should be the same function as before (could not think of the need of native float multiplication here).

However, this change would make str combo inputs possible for the argument target_size.
Particular useful if you want to have the size selection outside of the node GUI:
<img width="1407" height="741" alt="image" src="https://github.com/user-attachments/assets/0e89740d-b71e-47a0-9d75-f50ddea41e2d" />
